### PR TITLE
Update KDE packages list.

### DIFF
--- a/configs/kde/packages-extra.x86_64
+++ b/configs/kde/packages-extra.x86_64
@@ -49,7 +49,6 @@ vulkan-tools
 ### Others
 ##
 #
-byobu
 cpio
 cpupower
 dmidecode
@@ -70,4 +69,3 @@ unrar
 whois
 wireguard-tools
 zip
-zsh-autosuggestions

--- a/configs/kde/packages-kde.x86_64
+++ b/configs/kde/packages-kde.x86_64
@@ -25,7 +25,7 @@ gst-libav
 gst-plugins-ugly
 gwenview
 intel-media-driver
-jre8-openjdk
+jre-openjdk
 juk
 k3b
 kaddressbook
@@ -60,7 +60,6 @@ kmouth
 knotes
 kolourpaint
 kompare
-konqueror
 kontact
 konversation
 korganizer
@@ -113,6 +112,9 @@ skanlite
 spectacle
 sweeper
 system-config-printer
+telepathy-gabble
+telepathy-haze
+telepathy-idle
 telepathy-kde-approver
 telepathy-kde-auth-handler
 telepathy-kde-call-ui
@@ -120,9 +122,6 @@ telepathy-kde-contact-list
 telepathy-kde-contact-runner
 telepathy-kde-desktop-applets
 telepathy-kde-filetransfer-handler
-telepathy-gabble
-telepathy-haze
-telepathy-idle
 telepathy-kde-integration-module
 telepathy-kde-send-file
 telepathy-kde-text-ui


### PR DESCRIPTION
Removed some packages:
- byobu: We already have Konsole in there.
(Also, this breaks the CTRL+ALT+T shortcut to launch a Terminal, maybe because we have more than one)
- zsh-autosuggestions: We can install this when we install ZSH, this way it's just bloat.
- Konqueror: (we already have `Dolphin` + `Firefox` for that.)

Other changes:
+ Switch to latest JRE.
+ Alphabetically sort the packages list.
