### PR TITLE
Add `xdg-desktop-portal` to KDE packages.

### DIFF
--- a/configs/kde/packages-kde.x86_64
+++ b/configs/kde/packages-kde.x86_64
@@ -131,6 +131,7 @@ telepathy-salut
 user-manager
 vdpauinfo
 virtualgl
+xdg-desktop-portal
 xdg-desktop-portal-kde
 xdg-user-dirs
 xf86-input-elographics


### PR DESCRIPTION
According to [this post](https://phabricator.kde.org/T10189), the `xdg-desktop-portal-kde` is simply a plugin for the `xdg-desktop-portal` package. This helps us to get KDE dialogs instead of the GTK3 ones on many apps such as Firefox.

This also needs the `GTK_USE_PORTAL=1` environment variable to be set to use KDE dialogs.