### PR TITLE
Install default sway browser

### DIFF
--- a/profiles/sway/packages.x86_64
+++ b/profiles/sway/packages.x86_64
@@ -123,9 +123,9 @@ zsh
 # Required or recommended
 acpi
 acpid
-alacritty
 alsa-firmware
 dmenu
+foot
 intel-media-driver
 libcanberra-pulse
 libva-intel-driver


### PR DESCRIPTION
Sway moved to use `foot` instead of `alacritty` by default

Adding `foot` package so that "Menu+D" successfully opens a terminal again in default installation.
Also, removing alacritty which is not in use anymore.