### PR TITLE
add support for additional packages (`--add-pkg`)

### DIFF
--- a/archuseriso/aui-mkiso
+++ b/archuseriso/aui-mkiso
@@ -1115,6 +1115,7 @@ _validate_common_requirements_buildmode_iso_netboot() {
             (( validation_error=validation_error+1 ))
             _msg_error "No package specified in '${packages}'." 0
         fi
+        pkg_list+=("${pkg_list_additions[@]}")
     else
         (( validation_error=validation_error+1 ))
         _msg_error "Packages file '${packages}' does not exist." 0


### PR DESCRIPTION
Commit a8ebc5908d0a0421bcabce112a594437701ea6c3 (I presume accidentally) removed support for `--add-pkg` argument. The array for additional packages is set but never used.

add `pkg_list_additions` members to the `pkg_list` array after reading packages from the list files.